### PR TITLE
add: 将组合在一个姓氏条目里的以分号分隔的名字拆开

### DIFF
--- a/chrome/content/overlay.xul
+++ b/chrome/content/overlay.xul
@@ -2,7 +2,7 @@
 <?xml-stylesheet href="chrome://jasminum/skin/overlay.css" type="text/css"?>
 <!DOCTYPE overlay SYSTEM "chrome://jasminum/locale/overlay.dtd">
 
-<overlay id="jasminum" 
+<overlay id="jasminum"
     xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
 
     <!-- <popup id="zotero-collectionmenu">
@@ -11,17 +11,17 @@
     </popup> -->
 
     <menupopup id="zotero-itemmenu">
-		<menuseparator id="jasminum-separator"/>
-		<menu id="jasminum-popup-menu1" 
-            label="&jasminum.menu.CNKI.label;" 
+        <menuseparator id="jasminum-separator"/>
+        <menu id="jasminum-popup-menu1"
+            label="&jasminum.menu.CNKI.label;"
             class="menu-iconic jasminum-cnki-icon">
-			<menupopup id="jasminum">
+            <menupopup id="jasminum">
                 <menuitem
                     id="jasminum-itemmenu-search"
                     label="&jasminum.menu.CNKI.update.label;"
-                    class="menuitem-iconic jasminum-searchCNKI-icon" 
+                    class="menuitem-iconic jasminum-searchCNKI-icon"
                     oncommand="Zotero.Jasminum.searchSelectedItems();"/>
-		        <menuitem
+                <menuitem
                     id="jasminum-itemmenu-bookmark"
                     label="&jasminum.menu.CNKI.addBookmark.label;"
                     class="menuitem-iconic jasminum-bookmark-icon"
@@ -31,33 +31,38 @@
                     label="&jasminum.menu.CNKI.updateCiteCSSCI.label;"
                     class="menuitem-iconic jasminum-cssci-icon"
                     oncommand="Zotero.Jasminum.updateCiteCSSCIItems();"/>
-			</menupopup>
-		</menu>
+            </menupopup>
+        </menu>
         <menu id="jasminum-popup-menu2"
             label="&jasminum.menu.tools.label;"
             class="menu-iconic jasminum-tools-icon">
             <menupopup>
-                <menuitem 
+                <menuitem
                     label="&jasminum.menu.tools.namesplit.label;"
                     class="menuitem-iconic jasminum-name-icon"
                     oncommand="Zotero.Jasminum.splitNameM();"/>
-				<menuitem 
+                <menuitem
                     label="&jasminum.menu.tools.namemerge.label;"
                     class="menuitem-iconic jasminum-name-icon"
                     oncommand="Zotero.Jasminum.mergeNameM();"/>
-                <menuitem 
+                <menuitem
+                    label="&jasminum.menu.tools.semicolonNamesSplit.label;"
+                    class="menuitem-iconic jasminum-name-icon"
+                    oncommand="Zotero.Jasminum.splitSemicolonNamesN();"
+                    />
+                <menuitem
                     label="&jasminum.menu.tools.removeDot.label;"
                     class="menuitem-iconic jasminum-default-icon"
                     oncommand="Zotero.Jasminum.removeDotM();"/>
-                <menuitem 
+                <menuitem
                     label="&jasminum.menu.tools.language.label;"
                     class="menuitem-iconic jasminum-zh-icon"
                     oncommand="Zotero.Jasminum.setLanguageItems();"/>
             </menupopup>
         </menu>
-		
-	</menupopup>
+
+    </menupopup>
 
     <script src="chrome://zotero/content/include.js"/>
-    <script src="chrome://jasminum/content/scripts/include.js"/>	
+    <script src="chrome://jasminum/content/scripts/include.js"/>
 </overlay>

--- a/chrome/content/scripts/jasminum.js
+++ b/chrome/content/scripts/jasminum.js
@@ -367,6 +367,45 @@ Zotero.Jasminum = new function () {
         }
     };
 
+    this.splitSemicolonNamesN = async function () {
+        var items = ZoteroPane.getSelectedItems();
+        this.splitSemicolonNames(items);
+    }
+
+    /**
+     * 在知网搜索结果列表添加文献时，可能导致该文献的作者名变成类似于 姓名;姓名;姓名 的形式，
+     * 使用此函数将分号分隔的姓名分隔到不同的条目中。
+     */
+    this.splitSemicolonNames = async function (items) {
+        for (let item of items) {
+            const creators = item.getCreators();
+            var newlist = [];
+            for (let creator of creators) {
+                if (
+                    creator.lastName.search(";") &&
+                    creator.firstName === ""
+                ) {
+                    const names = creator.lastName.split(";").filter(s => s !== "");
+                    for (let name of names) {
+                        newlist.push(
+                            {
+                                "firstName": "",
+                                "lastName": name,
+                                "creatorType": "author"
+                            }
+                        );
+                    }
+                } else {
+                    newlist.push(creator);
+                }
+            }
+            if (newlist !== creators) {
+                item.setCreators(newlist);
+                item.saveTx();
+            }
+        }
+    }
+
     this.removeDotM = function () {
         var items = ZoteroPane.getSelectedItems();
         this.removeDot(items);

--- a/chrome/locale/en-US/overlay.dtd
+++ b/chrome/locale/en-US/overlay.dtd
@@ -5,6 +5,7 @@
 <!ENTITY jasminum.menu.tools.label "Tools">
 <!ENTITY jasminum.menu.tools.namesplit.label "Split Names">
 <!ENTITY jasminum.menu.tools.namemerge.label "Merge Names">
+<!ENTITY jasminum.menu.tools.semicolonNamesSplit.label "Split Semicoloned Names">
 <!ENTITY jasminum.menu.tools.removeDot.label "Remove Dot From Filename">
 <!ENTITY jasminum.menu.tools.language.label "Set Language">
 <!ENTITY jasminum.pdftkpath.label "PDFtk Service Install Folder,contains pdftk.exe or pdftk">

--- a/chrome/locale/zh-CN/overlay.dtd
+++ b/chrome/locale/zh-CN/overlay.dtd
@@ -5,6 +5,7 @@
 <!ENTITY jasminum.menu.tools.label "小工具">
 <!ENTITY jasminum.menu.tools.namesplit.label "拆分姓名">
 <!ENTITY jasminum.menu.tools.namemerge.label "合并姓名">
+<!ENTITY jasminum.menu.tools.semicolonNamesSplit.label "从分号拆分名字">
 <!ENTITY jasminum.menu.tools.removeDot.label "去除文件名中逗号">
 <!ENTITY jasminum.menu.tools.language.label "设置默认语言">
 <!ENTITY jasminum.pdftkpath.label "PDFtk Service 安装路径">


### PR DESCRIPTION
在知网搜索结果页面将文献列表添加到 Zotero 时可能出现这样的问题。
添加的此功能用于将这些组合的名字拆开为独立的条目。如图所示：

![Snipaste_2022-04-03_19-50-49](https://user-images.githubusercontent.com/36528430/161426740-1f00454f-f343-4382-aac8-a0357485e10b.png)

