### PR TITLE
add: 允许根据标题的内容来自动设置语言

### DIFF
--- a/chrome/content/preferences.xul
+++ b/chrome/content/preferences.xul
@@ -43,7 +43,7 @@
                                     <label value="&language.label;" style="padding-top: 6px;"/>
                                     <menulist flex="1" editable="true" id="jasminum.language" preference="pref-jasminum.language" maxwidth="100" >
                                         <menupopup>
-                                            <menuitem label="zh_CN" value="zh_CN"/>
+                                            <menuitem label="zh-CN" value="zh-CN"/>
                                             <menuitem label="cn" value="cn"/>
                                         </menupopup>
                                     </menulist>
@@ -53,7 +53,7 @@
                                     <label value="&foreignlanguage.label;" style="padding-top: 6px;"/>
                                     <menulist flex="1" editable="true" id="jasminum.foreignlanguage" preference="pref-jasminum.foreignlanguage" maxwidth="100" >
                                         <menupopup>
-                                            <menuitem label="en_US" value="en_US"/>
+                                            <menuitem label="en-US" value="en-US"/>
                                             <menuitem label="en" value="en"/>
                                         </menupopup>
                                     </menulist>

--- a/chrome/content/preferences.xul
+++ b/chrome/content/preferences.xul
@@ -17,6 +17,8 @@
                 <preference id="pref-jasminum.zhnamedot" name="extensions.zotero.jasminum.zhnamedot" type="bool"/>
                 <preference id="pref-jasminum.language" name="extensions.zotero.jasminum.language" type="string"/>
                 <preference id="pref-jasminum.autolanguage" name="extensions.zotero.jasminum.autolanguage" type="bool"/>
+                <preference id="pref-jasminum.foreignlanguage" name="extensions.zotero.jasminum.foreignlanguage" type="string"/>
+                <preference id="pref-jasminum.completelanguage" name="extensions.zotero.jasminum.completelanguage" type="bool"/>
                 <preference id="pref-jasminum.attachment" name="extensions.zotero.jasminum.attachment" type="string"/>
                 <preference id="pref-jasminum.citefield" name="extensions.zotero.jasminum.citefield" type="string"/>
             </preferences>
@@ -43,6 +45,16 @@
                                         <menupopup>
                                             <menuitem label="zh_CN" value="zh_CN"/>
                                             <menuitem label="cn" value="cn"/>
+                                        </menupopup>
+                                    </menulist>
+                                </row>
+                                <row>
+                                    <checkbox id="jasminum.completelanguage" label="&completelanguage.label;" preference="pref-jasminum.completelanguage"/>
+                                    <label value="&foreignlanguage.label;" style="padding-top: 6px;"/>
+                                    <menulist flex="1" editable="true" id="jasminum.foreignlanguage" preference="pref-jasminum.foreignlanguage" maxwidth="100" >
+                                        <menupopup>
+                                            <menuitem label="en_US" value="en_US"/>
+                                            <menuitem label="en" value="en"/>
                                         </menupopup>
                                     </menulist>
                                 </row>

--- a/chrome/content/scripts/jasminum.js
+++ b/chrome/content/scripts/jasminum.js
@@ -63,10 +63,10 @@ Zotero.Jasminum = new function () {
             Zotero.Prefs.set("jasminum.autolanguage", false);
         }
         if (Zotero.Prefs.get("jasminum.language") === undefined) {
-            Zotero.Prefs.set("jasminum.language", 'zh_CN');
+            Zotero.Prefs.set("jasminum.language", 'zh-CN');
         }
         if (Zotero.Prefs.get("jasminum.foreignlanguage") === undefined) {
-            Zotero.Prefs.set("jasminum.foreignlanguage", 'en_US');
+            Zotero.Prefs.set("jasminum.foreignlanguage", 'en-US');
         }
         if (Zotero.Prefs.get("jasminum.attachment") === undefined) {
             Zotero.Prefs.set("jasminum.attachment", 'pdf');

--- a/chrome/content/scripts/jasminum.js
+++ b/chrome/content/scripts/jasminum.js
@@ -65,6 +65,9 @@ Zotero.Jasminum = new function () {
         if (Zotero.Prefs.get("jasminum.language") === undefined) {
             Zotero.Prefs.set("jasminum.language", 'zh_CN');
         }
+        if (Zotero.Prefs.get("jasminum.foreignlanguage") === undefined) {
+            Zotero.Prefs.set("jasminum.foreignlanguage", 'en_US');
+        }
         if (Zotero.Prefs.get("jasminum.attachment") === undefined) {
             Zotero.Prefs.set("jasminum.attachment", 'pdf');
         }
@@ -534,6 +537,11 @@ Zotero.Jasminum = new function () {
      */
     this.setLanguage = async function (item) {
         let defaultLanguage = Zotero.Prefs.get("jasminum.language");
+        let langRegex = new RegExp("[\u4e00-\u9fa5]")
+        if (Zotero.Prefs.get("jasminum.completelanguage") && !langRegex.test(item.getField("title"))) {
+            // 当勾选了“根据标题设置语言栏”，并且 标题 中不含中文时，设置语言为“默认外文语言”
+            defaultLanguage = Zotero.Prefs.get("jasminum.foreignlanguage");
+        }
         if (item.getField("language") != defaultLanguage) {
             item.setField("language", defaultLanguage);
             await item.saveTx();

--- a/chrome/locale/en-US/overlay.dtd
+++ b/chrome/locale/en-US/overlay.dtd
@@ -13,6 +13,8 @@
 <!ENTITY autoupdate.label "Retrieve CNKI metadata when adding Chinese articles(pdf/caj)">
 <!ENTITY autolanguage.label "Set default language when adding Chinese articles">
 <!ENTITY language.label "Default LANG: ">
+<!ENTITY completelanguage.label "Set default language by title">
+<!ENTITY foreignlanguage.label "Default Foreign LANG: ">
 <!ENTITY cnkicite.label "Item field for CSSCI: ">
 <!ENTITY chinese "Setting">
 <!ENTITY translators "Unofficial Translators Repository">

--- a/chrome/locale/zh-CN/overlay.dtd
+++ b/chrome/locale/zh-CN/overlay.dtd
@@ -13,6 +13,8 @@
 <!ENTITY autoupdate.label "添加中文PDF/CAJ时自动从知网抓取题录">
 <!ENTITY autolanguage.label "中文条目时自动设置语言">
 <!ENTITY language.label "默认中文语言(选择或输入): ">
+<!ENTITY completelanguage.label "根据标题内容设置语言栏">
+<!ENTITY foreignlanguage.label "默认外文语言(选择或输入): ">
 <!ENTITY cnkicite.label "知网引用数存放字段(英文名): ">
 <!ENTITY chinese "中文插件设置">
 <!ENTITY translators "非官方维护中文翻译器">


### PR DESCRIPTION
当勾选 **根据标题设置语言栏** 后，使用 `小工具` -> `设置默认语言` ，将判断标题内是否含有中文。如果标题内含有中文则设置 **默认中文语言**，否则设置 **默认外文语言**。