### PR TITLE
fix: donot register menu separator for selected attachments

### DIFF
--- a/src/modules/menu.ts
+++ b/src/modules/menu.ts
@@ -107,11 +107,11 @@ export function registerMenu() {
   const separatorMenu: MenuitemOptions = {
     tag: "menuseparator",
     id: `${config.addonRef}-separator`,
-    isHidden: () =>
+    isHidden: (e) =>
       Zotero.getActiveZoteroPane()
         .getSelectedItems()
         .some((item) => {
-          return !(item.isTopLevelItem() && item.isRegularItem());
+          return !(isChineseTopAttachment(item) || isChinsesSnapshot(item) || item.isRegularItem());
         }),
   };
   const metadataMenu: MenuitemOptions = {

--- a/src/modules/menu.ts
+++ b/src/modules/menu.ts
@@ -34,7 +34,7 @@ export function isChinsesSnapshot(item: Zotero.Item): boolean {
   );
 }
 
-const metaddataMenuItems: MenuitemOptions[] = [
+const metadataMenuItems: MenuitemOptions[] = [
   {
     tag: "menuitem",
     label: "retrieveMetadata",
@@ -107,13 +107,19 @@ export function registerMenu() {
   const separatorMenu: MenuitemOptions = {
     tag: "menuseparator",
     id: `${config.addonRef}-separator`,
+    isHidden: () =>
+      Zotero.getActiveZoteroPane()
+        .getSelectedItems()
+        .some((item) => {
+          return !(item.isTopLevelItem() && item.isRegularItem());
+        }),
   };
   const metadataMenu: MenuitemOptions = {
     tag: "menu",
     label: getString("menu-metadata"),
     id: `${config.addonRef}-metadata-menu`,
     icon: `chrome://${config.addonRef}/content/icons/icon.png`,
-    children: metaddataMenuItems.map((subOption) => {
+    children: metadataMenuItems.map((subOption) => {
       const label = subOption.label as string;
       subOption.id = `${config.addonRef}-menuitem-${label}`;
       subOption.label = getString(`menuitem-${label}`);


### PR DESCRIPTION
- v1.0.3
    - Content menu list for selected regular items
![20250213_202051](https://github.com/user-attachments/assets/cefe233c-a637-4ad6-8a82-be695a836fc3)
    - Content menu list for selected attachment items
![20250213_202107](https://github.com/user-attachments/assets/d200154e-72d9-4490-9e78-8a0da6b1e0a7)
- This PR
    - Do not register separator in content menu list for selected attachment items
![20250213_202155](https://github.com/user-attachments/assets/dd948bb2-07f0-448e-b5fe-8477cb3904c0)

 