### PR TITLE
fix #396

### DIFF
--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-undef */
 pref("firstRun", true);
+pref("translatorsMended", false);
 /* tools */
 pref("enNameSplit", false);
 pref("zhNameSplit", false);
@@ -15,7 +16,7 @@ pref("cnkiAttachmentCookie", "");
 pref("pdfMatchFolder", "");
 /* update translators */
 pref("autoUpdateTranslators", true);
-pref("translatorUpdateTime", 0);
+pref("translatorUpdateTime", "0");
 pref("translatorSource", "");
 /* bookmark */
 pref("enableBookmark", true);

--- a/src/modules/preferences/main.ts
+++ b/src/modules/preferences/main.ts
@@ -61,6 +61,15 @@ export async function initPrefs() {
     );
   }
 
+  const translatortUpdateTime = getPref("translatorUpdateTime");
+  if (
+    typeof translatortUpdateTime !== "string" ||
+    /\D/.test(translatortUpdateTime)
+  ) {
+    Zotero.Prefs.clear(`${config.prefsPrefix}.translatorUpdateTime`);
+    setPref("translatorUpdateTime", "0");
+  }
+
   setPref("translatorSource", randomBaseUrl());
 }
 

--- a/typings/prefs.d.ts
+++ b/typings/prefs.d.ts
@@ -8,6 +8,7 @@ declare namespace _ZoteroTypes {
   interface Prefs {
     PluginPrefsMap: {
       "firstRun": boolean;
+      "translatorsMended": boolean;
       "enNameSplit": boolean;
       "zhNameSplit": boolean;
       "language": string;
@@ -19,7 +20,7 @@ declare namespace _ZoteroTypes {
       "cnkiAttachmentCookie": string;
       "pdfMatchFolder": string;
       "autoUpdateTranslators": boolean;
-      "translatorUpdateTime": number;
+      "translatorUpdateTime": string;
       "translatorSource": string;
       "enableBookmark": boolean;
     };


### PR DESCRIPTION
- If Jasminum has been installed before and the number of translators is relatively small, reset it directly.
- Handled related preference compatibility issues.